### PR TITLE
Specify that mime-construct cannot run its arguments

### DIFF
--- a/overrides/perl5.36.0-mime-construct-
+++ b/overrides/perl5.36.0-mime-construct-
@@ -1,0 +1,14 @@
+# notes:
+
+# $1 = verdict
+# $2 = executable
+execer(){
+	case "$2" in
+		mime-construct)
+			printf "cannot"
+			;;
+		*)
+			printf "$1"
+			;;
+	esac
+}


### PR DESCRIPTION
I’m marking this as a draft because I ran into a problem, and I’m not sure what to do about it. In my NixOS config, I use the attribute `perlPackages.mimeConstruct` to access `mime-construct`. At the moment, `perlPackages.mimeConstruct.name` is `perl5.36.0-mime-construct-1.11`, but that’s presumably going to change when a new version of Perl is released. Additionally, there’s already two different packages for `mime-construct` with different `name`s: `perl536Packages.mimeConstruct` and `perl534Packages.mimeConstruct`.

[I know that an override named `hello-` will match `hello-<anything>`](https://github.com/abathur/binlore/blob/5792c4c2dba47c1d8bc88880e853b409b56d1a0c/default.nix#L60), but is there a way to write an override that matches `perl<anything>-mime-construct-<anything>`?
